### PR TITLE
SONAR-19032 Fix extension style following MIUI css classes cleanup

### DIFF
--- a/src/main/ts/components/CAYCPresentation.tsx
+++ b/src/main/ts/components/CAYCPresentation.tsx
@@ -76,6 +76,10 @@ const Illustration = styled.img({
 
 const Title = styled.h1({
   marginBottom: '2rem',
+  lineHeight: '24px',
+  color: 'rgb(29, 33, 47)',
+  fontSize: '16px',
+  fontWeight: 400,
 });
 
 const Paragraph = styled.p({

--- a/src/main/ts/components/Chart.tsx
+++ b/src/main/ts/components/Chart.tsx
@@ -35,8 +35,8 @@ import useData, { ProjectOption } from './useData';
 
 const CHART_SIDEBAR_WIDTH = 250;
 const DEBOUNCE_DELAY = 250;
-const ARROW = `data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' 
-  width='10' height='100'%3e%3cpath d='M5 99 L0 90 L5 90 L5 0 L6 0 L6 90 L10 90 L5 99' 
+const ARROW = `data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg'
+  width='10' height='100'%3e%3cpath d='M5 99 L0 90 L5 90 L5 0 L6 0 L6 90 L10 90 L5 99'
   stroke-width='1' fill='limegreen' stroke='limegreen'/%3e%3c/svg%3e`;
 
 const DEFAULT_PROJECT = {
@@ -256,6 +256,10 @@ const LeftPadded = styled.span({
 const Title = styled.h1({
   display: 'flex',
   alignItems: 'center',
+  lineHeight: '24px',
+  color: 'rgb(29, 33, 47)',
+  fontSize: '16px',
+  fontWeight: 400,
 });
 
 const Aligned = styled.div({
@@ -278,6 +282,7 @@ const Paragraph = styled.p({
 const Graph = styled.svg({
   border: '1px solid #ccc',
   borderRight: 'none',
+  overflow: 'visible',
 });
 
 const GraphAnnotation = styled.div({

--- a/src/main/ts/components/__tests__/utils-test.ts
+++ b/src/main/ts/components/__tests__/utils-test.ts
@@ -42,8 +42,8 @@ it('should compute issue decay properly', () => {
         { x: new Date(2020, 5, 1), y: 5000 },
         { x: new Date(2020, 6, 1), y: 6000 },
       ] as Array<{ x: Date; y: number }>,
-      new Date(2020, 2, 1)
-    )
+      new Date(2020, 2, 1),
+    ),
   ).toEqual([
     { x: new Date(2020, 2, 1), y: 2000 },
     { x: new Date(2020, 3, 1), y: 1963 },

--- a/src/main/ts/components/utils.ts
+++ b/src/main/ts/components/utils.ts
@@ -29,14 +29,14 @@ export function durationToMonths(duration?: Duration) {
 
 export function computeIssuesDecayForCaycPeriod(
   initialIssuesCount: number,
-  caycPeriodInMonths: number
+  caycPeriodInMonths: number,
 ) {
   return initialIssuesCount * Math.pow(1 - CAYC_DECAY_PER_YEAR, caycPeriodInMonths / monthsInYear);
 }
 
 export function generateCaycProjectionData(
   data: Array<{ x: Date; y: number }>,
-  caycStartingDate: Date
+  caycStartingDate: Date,
 ) {
   const caycStartingPointIndex = data.findIndex(({ x }) => isSameMonth(x, caycStartingDate));
 

--- a/src/main/ts/testHelpers.tsx
+++ b/src/main/ts/testHelpers.tsx
@@ -25,6 +25,6 @@ export function renderComponent(component: React.ReactElement) {
   render(
     <IntlProvider defaultLocale="en" locale="en">
       {component}
-    </IntlProvider>
+    </IntlProvider>,
   );
 }


### PR DESCRIPTION
Some of the elements like H1 or SVG were relying on some ambient CSS we had before the MIUI CSS cleanup.

Here is how it looked like on our MIUI cleanup branch after cleaning some of this CSS:
![image](https://github.com/SonarSource/sonar-cayc-stats-plugin/assets/1725611/b1bf7e24-cdc3-4542-bb54-4b0c1b0d4f5a)


I added these ambient CSS properties to the emotions component directly so that the style isn't broken:

![image](https://github.com/SonarSource/sonar-cayc-stats-plugin/assets/1725611/71f7f5a5-a3b6-4075-87c5-b12170c54cc2)

PS: seems like the images are not working while proxying.