### PR TITLE
BUILD-7788 Migrate slack notification

### DIFF
--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -13,7 +13,7 @@ jobs:
   slack-notifications:
     if: >-
       contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-')
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Send Slack Notification
         env:

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -5,6 +5,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   contents: read
   checks: read
   id-token: write

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Send Slack Notification
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         uses: SonarSource/gh-action_slack-notify@v1
         with:
           slackChannel: squad-workflow-standards-build-errors

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Send Slack Notification
         env:
-          GITHUB_TOKEN: ${ github.token }
-        uses: SonarSource/gh-action_slack-notify@1.0.0
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: SonarSource/gh-action_slack-notify@v1
         with:
           slackChannel: squad-workflow-standards-build-errors

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -1,13 +1,23 @@
 ---
 name: Slack Notifications
 on:
- check_run:
-  types: [rerequested, completed]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: read
+  checks: read
+  id-token: write
 
 jobs:
- slack-notifications:
-  permissions:
-   id-token: write  # to authenticate via OIDC
-  uses: SonarSource/gh-action_build-notify/.github/workflows/main.yaml@v1
-  with:
-   slackChannel: squad-workflow-standards-build-errors
+  slack-notifications:
+    if: >-
+      contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-')
+    runs-on: sonar-runner
+    steps:
+      - name: Send Slack Notification
+        env:
+          GITHUB_TOKEN: ${ github.token }
+        uses: SonarSource/gh-action_slack-notify@1.0.0
+        with:
+          slackChannel: squad-workflow-standards-build-errors


### PR DESCRIPTION
[CAYCPLUGIN-56](https://sonarsource.atlassian.net/browse/CAYCPLUGIN-56)

This PR updates the Slack notification action in .github/workflows/slack_notify.yml.

[CAYCPLUGIN-56]: https://sonarsource.atlassian.net/browse/CAYCPLUGIN-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ