### PR TITLE
CAYCPLUGIN-68 Bump mise to 2026.3.10 to fix freethreaded Python build selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  aws-auth:
+    name: AWS Authentication
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+    outputs:
+      docker_username: ${{ steps.login-ecr-public.outputs.docker_username_public_ecr_aws }}
+      docker_password: ${{ steps.login-ecr-public.outputs.docker_password_public_ecr_aws }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/${{ vars.AWS_CICD_ROLE }}
+          role-session-name: ${{ github.workflow }}-${{ github.run_id }}
+          mask-aws-account-id: 'false'
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registry-type: public
+          mask-password: 'false'
+
   build:
     runs-on: github-ubuntu-latest-s
     name: Build
@@ -33,7 +56,7 @@ jobs:
           artifactory-deployer-role: qa-deployer
 
   black_box_test:
-    needs: [build]
+    needs: [build, aws-auth]
     runs-on: github-ubuntu-latest-s
     name: Black Box Tests (${{ matrix.sonar_version }})
     if: |
@@ -53,6 +76,9 @@ jobs:
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:15
+        credentials:
+          username: ${{ needs.aws-auth.outputs.docker_username }}
+          password: ${{ needs.aws-auth.outputs.docker_password }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
-          version: 2025.7.12
+          version: 2026.3.10
       - uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           deploy-pull-request: true
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
-          version: 2025.7.12
+          version: 2026.3.10
       - name: Get build number
         id: build_number
         uses: SonarSource/ci-github-actions/get-build-number@v1
@@ -107,6 +107,7 @@ jobs:
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_PASSWORD;
       - name: Run black box tests
         env:
+          JAVA_TOOL_OPTIONS: -XX:-UseContainerSupport
           ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}
           ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_PASSWORD }}
@@ -142,7 +143,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           cache_save: false
-          version: 2025.7.12
+          version: 2026.3.10
       - uses: SonarSource/ci-github-actions/promote@v1
         with:
           promote-pull-request: true

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-java = "17.0"
+java = "21.0"
 maven = "3.9"
 node = "16.20.0"


### PR DESCRIPTION
## Summary
- Bump mise from 2025.7.12 to 2026.3.10 to fix freethreaded Python build selection bug

## Context
Mise v2025.x incorrectly selected freethreaded (no-GIL) Python builds, causing `mise ERROR failed to install core:python` failures in CI.